### PR TITLE
Point to guix channel that gxpkg comes from

### DIFF
--- a/README.org
+++ b/README.org
@@ -16,7 +16,7 @@ See https://github.com/vyzo/gerbil.
 
 ** Installation
 
-It is available as a ~gxpkg~ from *[[http://github.com/drewc/gerbil-ftw][github.com/drewc/ftw]]*.
+It is available as a ~gxpkg~ from *[[http://github.com/drewc/druix][github.com/drewc/druix]]*.
 
 #+BEGIN_SRC sh
 gxpkg install github.com/drewc/ftw


### PR DESCRIPTION
Hi, 

Does `gxpkg` depend on [druix](https://github.com/drewc/druix)?

What do you think of linking to the Guix channel repo for it?